### PR TITLE
fix: add rules field to mesh traffic permission policy spec

### DIFF
--- a/tfbuilder/policy.go
+++ b/tfbuilder/policy.go
@@ -18,6 +18,7 @@ const AllowAllTrafficPermissionSpec = `
         }
       }
     ]
+	rules = []
   }`
 
 type PolicyBuilder struct {


### PR DESCRIPTION
In https://github.com/Kong/terraform-provider-konnect-beta/pull/86, a new field `spec.rules`  is being added to Mesh Traffic Permission, which has `x-speakeasy-param-computed: false` - and if not declared, leads to invalid TF plan.