### PR TITLE
fix(customtypes): kumalabels defaults to null-map and constantly produces diff on planning

### DIFF
--- a/customtypes/kumalabels/empty.go
+++ b/customtypes/kumalabels/empty.go
@@ -1,0 +1,23 @@
+package kumalabels
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type EmptyKumaLabelsMapDefault struct{}
+
+func (EmptyKumaLabelsMapDefault) Description(context.Context) string {
+	return "defaults to empty map"
+}
+
+func (EmptyKumaLabelsMapDefault) MarkdownDescription(ctx context.Context) string {
+	return "defaults to empty map"
+}
+
+func (EmptyKumaLabelsMapDefault) DefaultMap(ctx context.Context, _ defaults.MapRequest, resp *defaults.MapResponse) {
+	resp.PlanValue = types.MapValueMust(types.StringType, map[string]attr.Value{})
+}


### PR DESCRIPTION
We don't care if labels are null or an empty map, that why if user hasn't provided labels we should default them to empty map.

Later in OAS we should update labels to have custom default:
```yaml
labels:
  description: The labels to help identity resources
  type: object
  default: {}
  additionalProperties:
    type: string
  x-speakeasy-param-computed: false
  x-speakeasy-terraform-custom-type:
    imports:
      - github.com/Kong/shared-speakeasy/customtypes/kumalabels
    schemaType: 'kumalabels.KumaLabelsMapType{MapType: types.MapType{ElemType: types.StringType}}'
    valueType: kumalabels.KumaLabelsMapValue
  x-speakeasy-terraform-custom-default:
    imports:
      - github.com/Kong/shared-speakeasy/customtypes/kumalabels
    schemaDefinition: kumalabels.EmptyKumaLabelsMapDefault{}
```

See https://github.com/Kong/terraform-provider-kong-mesh/issues/45 for additional context.
