### PR TITLE
fix: update mesh defaults hook to process empty slice

### DIFF
--- a/hooks/mesh_defaults/mesh_defaults_hook.go
+++ b/hooks/mesh_defaults/mesh_defaults_hook.go
@@ -45,7 +45,7 @@ func BeforeRequest(matchFeatureRequest func(r *http.Request) bool, matchPolicies
 				},
 			}
 
-			if _, exists := bodyMap["features"]; !exists {
+			if !containsNonEmpty(bodyMap, "features") {
 				bodyMap["features"] = defaultFeatures
 			}
 
@@ -81,7 +81,7 @@ func BeforeRequest(matchFeatureRequest func(r *http.Request) bool, matchPolicies
 			}
 
 			// Define the default "skipCreatingInitialPolicies" value
-			if _, exists := bodyMap["skipCreatingInitialPolicies"]; !exists {
+			if !containsNonEmpty(bodyMap, "skipCreatingInitialPolicies") {
 				bodyMap["skipCreatingInitialPolicies"] = []string{"*"}
 			}
 
@@ -95,5 +95,21 @@ func BeforeRequest(matchFeatureRequest func(r *http.Request) bool, matchPolicies
 			req.Header.Set("Content-Type", "application/json")
 		}
 		return req, nil
+	}
+}
+
+func containsNonEmpty(obj map[string]interface{}, key string) bool {
+	value, exists := obj[key]
+	if !exists {
+		return false
+	}
+
+	switch v := value.(type) {
+	case []interface{}:
+		return len(v) > 0
+	case map[string]interface{}:
+		return len(v) > 0
+	default:
+		return value != nil
 	}
 }


### PR DESCRIPTION
In this PR, we are adding a change to mesh default hook, so that even when the `features` field is an empty slice, we add the defaults.
This workaround is needed because of a change in speakeasy Marshalling - which now marshals `features` to `[]` when not declared. ([Discussion started here](https://kongstrong.slack.com/archives/C05MLAA216D/p1771825505802089) with speakeasy)

Tested on local by replacing the hook, and running the tests on the beta provider.
<img width="1036" height="858" alt="Screenshot 2026-02-23 at 11 21 16 AM" src="https://github.com/user-attachments/assets/087c2d68-ad65-45b1-a24a-d5f5009a8a49" />
