### PR TITLE
feat(mesh_defaults): default cp version to v3

### DIFF
--- a/hooks/mesh_defaults/mesh_defaults_hook.go
+++ b/hooks/mesh_defaults/mesh_defaults_hook.go
@@ -8,7 +8,7 @@ import (
 )
 
 // BeforeRequest defaults mesh related fields:
-// for mesh control plane - the "features" field to include "MeshCreation" and "HostnameGeneratorCreation" with "enabled" set to false
+// for mesh control plane - the "features" field to include "MeshCreation" and "HostnameGeneratorCreation" with "enabled" set to false, and the "version" field to "v3"
 // for mesh - the "skipCreatingInitialPolicies" field to include "*".
 func BeforeRequest(matchFeatureRequest func(r *http.Request) bool, matchPoliciesRequest func(r *http.Request) bool) func(req *http.Request) (*http.Request, error) {
 	return func(req *http.Request) (*http.Request, error) {
@@ -47,6 +47,11 @@ func BeforeRequest(matchFeatureRequest func(r *http.Request) bool, matchPolicies
 
 			if _, exists := bodyMap["features"]; !exists {
 				bodyMap["features"] = defaultFeatures
+			}
+
+			// Default the "version" field to "v3"
+			if _, exists := bodyMap["version"]; !exists {
+				bodyMap["version"] = "v3"
 			}
 
 			newBody, err := json.Marshal(bodyMap)


### PR DESCRIPTION
## Motivation

On mesh control plane creation we already default the `features` field.
The `version` field should also default to `v3` so callers get a sensible default without having to set it explicitly.

## Changes

Defaults the mesh control plane `version` field to `v3` on creation, the same way `features` is already defaulted on that request.

## Implementation information

In the `matchFeatureRequest` branch of `BeforeRequest`, after defaulting `features`, we inject `"version": "v3"` into the body when it's absent.
For konnect this matches `POST /v1/mesh/control-planes`.
If the caller sets `version` explicitly, it's left untouched - same behavior as `features`.

## Related

xrel https://github.com/Kong/kong-mesh/issues/10347