### PR TITLE
feat(hclbuilder): add v3-compatible mesh/mtp test cases

### DIFF
--- a/hclbuilder/test_cases.go
+++ b/hclbuilder/test_cases.go
@@ -172,7 +172,7 @@ func CreatePolicyWithRulesAndModifyFields(
 					allow = [{
 						spiffe_id = {
 							type  = "Prefix"
-							value = "spiffe://"
+							value = "spiffe://example.org"
 						}
 					}]
 				}
@@ -198,7 +198,7 @@ func CreatePolicyWithRulesAndModifyFields(
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(policyResourcePath, plancheck.ResourceActionNoop),
-						plancheck.ExpectKnownValue(policyResourcePath, spiffeValuePath, knownvalue.StringExact("spiffe://")),
+						plancheck.ExpectKnownValue(policyResourcePath, spiffeValuePath, knownvalue.StringExact("spiffe://example.org")),
 					},
 				},
 			},
@@ -207,7 +207,7 @@ func CreatePolicyWithRulesAndModifyFields(
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(policyResourcePath, plancheck.ResourceActionNoop),
-						plancheck.ExpectKnownValue(policyResourcePath, spiffeValuePath, knownvalue.StringExact("spiffe://")),
+						plancheck.ExpectKnownValue(policyResourcePath, spiffeValuePath, knownvalue.StringExact("spiffe://example.org")),
 					},
 				},
 			},
@@ -289,7 +289,7 @@ func NotImportedResourceWithRulesShouldError(
 					allow = [{
 						spiffe_id = {
 							type  = "Prefix"
-							value = "spiffe://"
+							value = "spiffe://example.org"
 						}
 					}]
 				}

--- a/hclbuilder/test_cases.go
+++ b/hclbuilder/test_cases.go
@@ -89,10 +89,7 @@ func CreateMeshAndModifyFields(
 
 // CreateMeshWithMtlsAndModifyFields creates a mesh and modifies fields on it,
 // exercising `mtls` (a builtin CA backend) instead of `constraints`/`routing`.
-// Newer (v3) control planes don't round-trip `constraints` or
-// `routing.default_forbid_mesh_external_service_access` on read, so
-// CreateMeshAndModifyFields can't reach an empty refresh plan against them. This
-// variant modifies fields that do round-trip. The old function is kept for
+// V3 control planes don't have these fields. The old function is kept for
 // backwards compatibility.
 func CreateMeshWithMtlsAndModifyFields(
 	providerFactory map[string]func() (tfprotov6.ProviderServer, error),

--- a/hclbuilder/test_cases.go
+++ b/hclbuilder/test_cases.go
@@ -148,6 +148,73 @@ func CreatePolicyAndModifyFields(
 	}
 }
 
+// CreatePolicyWithRulesAndModifyFields creates a policy using the `rules` spec
+// format (required by newer control planes) and modifies fields on it. It is the
+// `rules` equivalent of CreatePolicyAndModifyFields, which uses the legacy `from`
+// format. The old function is kept for backwards compatibility.
+func CreatePolicyWithRulesAndModifyFields(
+	providerFactory map[string]func() (tfprotov6.ProviderServer, error),
+	builder *Builder,
+	mesh *Builder,
+	policy *Builder,
+) resource.TestCase {
+	policyResourcePath := policy.ResourcePath()
+	meshResourcePath := mesh.ResourcePath()
+
+	// Upsert dependency of policy on mesh
+	policy.DependsOn(mesh)
+
+	// Set policy spec using AddAttribute with HCL string
+	policy.AddAttribute("labels", `{}`).
+		AddAttribute("spec", `{
+			rules = [{
+				default = {
+					allow = [{
+						spiffe_id = {
+							type  = "Prefix"
+							value = "spiffe://"
+						}
+					}]
+				}
+			}]
+		}`)
+
+	spiffeValuePath := tfjsonpath.New("spec").AtMapKey("rules").AtSliceIndex(0).AtMapKey("default").AtMapKey("allow").AtSliceIndex(0).AtMapKey("spiffe_id").AtMapKey("value")
+
+	return resource.TestCase{
+		ProtoV6ProviderFactories: providerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: builder.Upsert(mesh).Upsert(policy).Build(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(meshResourcePath, plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(policyResourcePath, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: builder.Upsert(mesh).Upsert(policy).Build(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(policyResourcePath, plancheck.ResourceActionNoop),
+						plancheck.ExpectKnownValue(policyResourcePath, spiffeValuePath, knownvalue.StringExact("spiffe://")),
+					},
+				},
+			},
+			{
+				Config: builder.Upsert(mesh).Upsert(policy).Build(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(policyResourcePath, plancheck.ResourceActionNoop),
+						plancheck.ExpectKnownValue(policyResourcePath, spiffeValuePath, knownvalue.StringExact("spiffe://")),
+					},
+				},
+			},
+		},
+	}
+}
+
 // NotImportedResourceShouldError tests error handling for non-imported resources
 func NotImportedResourceShouldError(
 	providerFactory map[string]func() (tfprotov6.ProviderServer, error),
@@ -173,6 +240,58 @@ func NotImportedResourceShouldError(
 				}
 				default = {
 					action = "Allow"
+				}
+			}]
+		}`)
+
+	return resource.TestCase{
+		ProtoV6ProviderFactories: providerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: builder.Upsert(mesh).Build(),
+			},
+			{
+				PreConfig:   preConfigFn,
+				Config:      builder.Upsert(mesh).Upsert(policy).Build(),
+				ExpectError: expectedErr,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(policyResourcePath, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	}
+}
+
+// NotImportedResourceWithRulesShouldError is the `rules` spec equivalent of
+// NotImportedResourceShouldError. The old function is kept for backwards
+// compatibility.
+func NotImportedResourceWithRulesShouldError(
+	providerFactory map[string]func() (tfprotov6.ProviderServer, error),
+	builder *Builder,
+	mesh *Builder,
+	policy *Builder,
+	preConfigFn func(),
+) resource.TestCase {
+	expectedErr := regexp.MustCompile(`MeshTrafficPermission already exists`)
+
+	policyResourcePath := policy.ResourcePath()
+
+	// Upsert dependency of policy on mesh
+	policy.DependsOn(mesh)
+
+	// Set policy spec using AddAttribute with HCL string
+	policy.AddAttribute("labels", `{}`).
+		AddAttribute("spec", `{
+			rules = [{
+				default = {
+					allow = [{
+						spiffe_id = {
+							type  = "Prefix"
+							value = "spiffe://"
+						}
+					}]
 				}
 			}]
 		}`)

--- a/hclbuilder/test_cases.go
+++ b/hclbuilder/test_cases.go
@@ -87,6 +87,66 @@ func CreateMeshAndModifyFields(
 	}
 }
 
+// CreateMeshWithMtlsAndModifyFields creates a mesh and modifies fields on it,
+// exercising `mtls` (a builtin CA backend) instead of `constraints`/`routing`.
+// Newer (v3) control planes don't round-trip `constraints` or
+// `routing.default_forbid_mesh_external_service_access` on read, so
+// CreateMeshAndModifyFields can't reach an empty refresh plan against them. This
+// variant modifies fields that do round-trip. The old function is kept for
+// backwards compatibility.
+func CreateMeshWithMtlsAndModifyFields(
+	providerFactory map[string]func() (tfprotov6.ProviderServer, error),
+	builder *Builder,
+	mesh *Builder,
+) resource.TestCase {
+	meshResourcePath := mesh.ResourcePath()
+	return resource.TestCase{
+		ProtoV6ProviderFactories: providerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: builder.Upsert(mesh).Build(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(meshResourcePath, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: builder.Upsert(mesh.
+					AddAttribute("mtls.enabled_backend", `"ca-1"`).
+					AddAttribute("mtls.backends", `[{ name = "ca-1", type = "builtin" }]`)).Build(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(meshResourcePath, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(meshResourcePath, tfjsonpath.New("mtls").AtMapKey("enabled_backend"), knownvalue.StringExact("ca-1")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: builder.Upsert(mesh.
+					RemoveAttribute("mtls")).Build(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(meshResourcePath, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(meshResourcePath, tfjsonpath.New("mtls"), knownvalue.Null()),
+					},
+				},
+			},
+			{
+				Config: builder.Remove(mesh).Build(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(meshResourcePath, plancheck.ResourceActionDestroy),
+					},
+				},
+			},
+		},
+	}
+}
+
 // CreatePolicyAndModifyFields creates a policy and modifies fields on it
 func CreatePolicyAndModifyFields(
 	providerFactory map[string]func() (tfprotov6.ProviderServer, error),


### PR DESCRIPTION
## Motivation

Newer Kong Mesh / Kuma control planes (v3+) changed two behaviors that break the existing shared test cases:

- MeshTrafficPermission rejects the legacy `spec.from` format with `400 policy must define rules` - it wants `spec.rules`.
- Mesh no longer round-trips `constraints` or `routing.default_forbid_mesh_external_service_access` on read (the PUT is accepted but the GET omits them), so a mesh modify test can never reach an empty refresh plan.

Downstream providers running against a v3 control plane can't use the current helpers.

## Changes

Add v3-compatible variants, keeping the originals unchanged for backwards compatibility.

- `CreatePolicyWithRulesAndModifyFields` (rules equivalent of `CreatePolicyAndModifyFields`)
- `NotImportedResourceWithRulesShouldError` (rules equivalent of `NotImportedResourceShouldError`)
- `CreateMeshWithMtlsAndModifyFields` (mesh modify test that exercises a builtin `mtls` backend, which does round-trip, instead of `constraints`/`routing`)

## Implementation information

The rules helpers use a minimal allow-all `rules` spec with a valid Spiffe ID (bare `spiffe://` is rejected by the control plane for a missing trust domain):

```hcl
spec = {
  rules = [{
    default = {
      allow = [{
        spiffe_id = { type = "Prefix", value = "spiffe://example.org" }
      }]
    }
  }]
}
```

Verified end-to-end against the terraform-provider-kong-mesh `mesh-v3` branch acceptance suite (all 6 tests green) with the control plane `kong/kuma-cp:0.0.0-preview.v84ec98599`.

https://claude.ai/code/session_014NSF2E1mJxmsW9Rqxo63AT