### PR TITLE
fix(kumalabels): normalise missing API labels to an empty map

### DIFF
--- a/customtypes/kumalabels/kumalabels.go
+++ b/customtypes/kumalabels/kumalabels.go
@@ -62,8 +62,19 @@ func (t KumaLabelsMapType) Equal(o attr.Type) bool {
 }
 
 func (t KumaLabelsMapType) ValueFromMap(ctx context.Context, in basetypes.MapValue) (basetypes.MapValuable, diag.Diagnostics) {
+	// Null means "the API returned no labels": this is the Go/API -> value direction, only
+	// reached from generated RefreshFrom* code and reflection, never from config or state
+	// (ValueFromTerraform short-circuits null before it gets here).
+	//
+	// Every schema using this type is Computed+Optional with EmptyKumaLabelsMapDefault, so
+	// "no labels" plans as an empty map, never null. Returning null here would leave the
+	// refreshed state disagreeing with that plan forever, and semantic equality can't fix it
+	// after the fact - the framework skips it whenever either side is null.
+	//
+	// Keeping the config direction null-preserving is what stops #30 from coming back on
+	// resources where labels is not Computed.
 	if in.IsNull() {
-		return KumaLabelsMapValue{MapValue: basetypes.NewMapNull(types.StringType)}, nil
+		return KumaLabelsMapValue{MapValue: types.MapValueMust(types.StringType, map[string]attr.Value{})}, nil
 	}
 
 	allLabels := in.Elements()

--- a/customtypes/kumalabels/kumalabels_test.go
+++ b/customtypes/kumalabels/kumalabels_test.go
@@ -60,9 +60,9 @@ func TestKumaLabelsMapType_ValueFromMap(t *testing.T) {
 			expectedOutput: map[string]string{},
 		},
 		{
-			name:           "input is nil — expect nil",
+			name:           "input is nil (API returned no labels) - expect empty map to match the schema default",
 			input:          nil,
-			expectedOutput: nil,
+			expectedOutput: map[string]string{},
 		},
 		{
 			name:           "input is empty map — expect empty map",


### PR DESCRIPTION
## What

`ValueFromMap` now returns an empty map instead of null when the input map is null.

## Why

The mesh API omits `labels` entirely when a resource has none.
Refresh turned that into a null map in state, while the plan held the empty map from `EmptyKumaLabelsMapDefault`.
Null vs `{}` is a permanent diff, so every `konnect_mesh` acceptance test failed with "After applying this test step, the refresh plan was not empty":

```
~ kri    = "kri_m____default_" -> (known after apply)
+ labels = {}
```

(`kri` is just collateral - it goes back to showing its value once labels stops diffing.)

Semantic equality can't fix this after the fact.
The framework skips it whenever either side is null - see `fwschemadata/value_semantic_equality.go:52-60`.

This finishes what #45 started.
That PR added `EmptyKumaLabelsMapDefault` so an absent `labels` plans as `{}`, but left the refresh side returning null, so the two never agreed.

## Why this doesn't regress #30

The two directions are deliberately asymmetric.

`ValueFromTerraform` still short-circuits null before delegating, so config and state stay null-preserving.
That's the guard #30 needed, and it still matters for any resource where `labels` isn't Computed - otherwise you get `planned an invalid value cty.MapValEmpty for a non-computed attribute` again.

`ValueFromMap` only sees null in the API -> value direction, from generated `RefreshFrom*` code.
All 27 schemas using this type in terraform-provider-konnect-beta are `Computed + Optional + Default: EmptyKumaLabelsMapDefault{}`, so "no labels" always plans as `{}` there, never null.

## Testing

- `go test ./kumalabels/...` - 9 passed.
- Full `TestMesh` in terraform-provider-konnect-beta against `us.api.konghq.tech`, with `go.mod` `replace`d onto this branch - 9 passed, previously 8 of 9 subtests failed.

Confirmed the API behaviour directly:

```
GET /v1/mesh/control-planes/{cp}/api/meshes/default
{"type":"Mesh","name":"default","creationTime":"...","modificationTime":"...","kri":"kri_m____default_"}
```

No `labels` key.
Mesh policies do return labels (`kuma.io/mesh` etc., filtered down to `{}` by this type), which is why only `konnect_mesh` broke.

## Follow-up

Consumers need a `customtypes` bump.
terraform-provider-konnect-beta currently pins `v0.2.5` while main is at `v0.3.0`, so it needs one regardless.